### PR TITLE
Added Xresources option for cursorfg and reverse-cursor (#31)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -81,16 +81,18 @@ static char *colorname[] = {
 
 	[255] = 0,
 
-	"#a7a7a7",
-	"#1e1e1e",
+	"#a7a7a7", 		/* [default] defaultfg */
+	"#1e1e1e",		/* [default] defaultbg */
+	"#a7a7a7",              /* [default] defaultcs */
+	"#1e1e1e",		/* [default] defaultrcs */
 	"black",
 };
 
 /* fg, bg, cursor, reverse cursor (references colorname indexes) */
 static unsigned int defaultfg = 256;
 static unsigned int defaultbg = 257;
-static unsigned int defaultcs = 256;
-static unsigned int defaultrcs = 257;
+static unsigned int defaultcs = 258;
+static unsigned int defaultrcs = 259;
 
 /* 2 4 6 7: █ _ | ☃ */
 static unsigned int cursorshape = 2;

--- a/src/st.c
+++ b/src/st.c
@@ -4786,6 +4786,18 @@ xrdb_load(void)
 
 		XRESOURCE_LOAD_STRING("foreground", colorname[256]);
 		XRESOURCE_LOAD_STRING("background", colorname[257]);
+		XRESOURCE_LOAD_STRING("cursorfg", colorname[258])
+		else {
+		  // this looks confusing because we are chaining off of the if
+		  // in the macro. probably we should be wrapping everything blocks
+		  // so this isn't possible...
+		  defaultcs = defaultfg;
+		}
+		XRESOURCE_LOAD_STRING("reverse-cursor", colorname[259])
+		else {
+		  // see above.
+		  defaultrcs = defaultbg;
+		}
 		XRESOURCE_LOAD_STRING("font", font);
 		XRESOURCE_LOAD_STRING("termname", termname);
 		XRESOURCE_LOAD_STRING("shell", shell);


### PR DESCRIPTION
* Added color slots for cursorfg/bg separated from foreground/background.

* Reverted the new cursor colors to the defaults.

* Made the cursorfg/bg colors link to fg/bg if they are not set.